### PR TITLE
Changes from background composer bc-4c8773a2-6087-4fdc-8014-6c47fc4ef2a8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,8 @@ jobs:
     - name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'
       with:
-        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+        workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+        service_account: '${{ secrets.GITHUB_ACTIONS_SA_EMAIL }}'
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v2'
@@ -122,7 +123,8 @@ jobs:
     - name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'
       with:
-        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+        workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+        service_account: '${{ secrets.GITHUB_ACTIONS_SA_EMAIL }}'
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v2'
@@ -150,7 +152,8 @@ jobs:
     - name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'
       with:
-        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+        workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+        service_account: '${{ secrets.GITHUB_ACTIONS_SA_EMAIL }}'
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v2'
@@ -197,7 +200,8 @@ jobs:
     - name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'
       with:
-        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+        workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+        service_account: '${{ secrets.GITHUB_ACTIONS_SA_EMAIL }}'
 
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v2'

--- a/backend/services/shipment-service/Dockerfile
+++ b/backend/services/shipment-service/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /app
 
 # Copy Go modules first for better caching
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 # Download dependencies
 RUN go mod download

--- a/backend/services/user-service/Dockerfile
+++ b/backend/services/user-service/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /app
 
 # Copy Go modules first for better caching
-COPY go.mod go.sum ./
+COPY go.mod ./
 
 # Download dependencies
 RUN go mod download


### PR DESCRIPTION
Update GCP authentication to Workload Identity Federation and fix Docker build errors.

The CI/CD workflow was failing due to an outdated GCP authentication method (`credentials_json`). This PR updates it to use Workload Identity Federation for enhanced security and compatibility. Additionally, Docker builds for `shipment-service` and `user-service` failed because their Dockerfiles attempted to copy `go.sum`, which was not present as these services do not have external Go dependencies. This change removes the unnecessary `go.sum` copy step.