### PR TITLE
Deploy GitHub project to Google Cloud

### DIFF
--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,109 @@
+# 🚀 Bringee GCP Deployment Checklist
+
+## Voraussetzungen
+- [ ] Google Cloud Projekt erstellt
+- [ ] Google Cloud SDK installiert (`gcloud`)
+- [ ] Terraform installiert
+- [ ] Docker installiert
+- [ ] GitHub Repository mit Code
+
+## Schnellstart (5 Minuten)
+
+### 1. Google Cloud Projekt einrichten
+```bash
+# Google Cloud SDK installieren (falls nicht vorhanden)
+curl https://sdk.cloud.google.com | bash
+exec -l $SHELL
+
+# Authentifizieren
+gcloud auth login
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### 2. Terraform Infrastruktur deployen
+```bash
+# Terraform initialisieren und deployen
+cd terraform
+terraform init
+terraform apply -var="gcp_project_id=YOUR_PROJECT_ID" -var="github_repository=YOUR_USERNAME/bringee"
+cd ..
+```
+
+### 3. GitHub Secrets konfigurieren
+1. Gehen Sie zu Ihrem GitHub Repository
+2. Settings > Secrets and variables > Actions
+3. Fügen Sie diese Secrets hinzu:
+   - `GCP_PROJECT_ID`: Ihre GCP Project ID
+   - `GCP_SA_KEY`: Service Account JSON Key
+
+### 4. Deployment testen
+```bash
+# Push zum main branch
+git add .
+git commit -m "Initial deployment"
+git push origin main
+```
+
+## Manuelles Deployment (Alternative)
+
+Falls die CI/CD Pipeline nicht funktioniert:
+
+```bash
+# Deployment-Skript ausführen
+chmod +x deploy-to-gcp.sh
+./deploy-to-gcp.sh
+```
+
+## Überprüfung
+
+Nach dem Deployment sollten Sie folgende Services haben:
+
+### Backend Services
+- [ ] User Service: `https://user-service-xxx-ew.a.run.app`
+- [ ] Shipment Service: `https://shipment-service-xxx-ew.a.run.app`
+
+### Frontend
+- [ ] Flutter Web App: `https://YOUR_PROJECT_ID.web.app`
+
+## Troubleshooting
+
+### Fehler: "Permission denied"
+```bash
+# Service Account Rollen überprüfen
+gcloud projects get-iam-policy YOUR_PROJECT_ID
+```
+
+### Fehler: "Project not found"
+```bash
+# Projekt auflisten
+gcloud projects list
+```
+
+### Fehler: "Artifact Registry not found"
+```bash
+# Terraform erneut ausführen
+cd terraform
+terraform apply
+cd ..
+```
+
+## Nützliche Befehle
+
+```bash
+# Services auflisten
+gcloud run services list
+
+# Logs anzeigen
+gcloud run services logs read user-service
+
+# Service URL abrufen
+gcloud run services describe user-service --format="value(status.url)"
+```
+
+## Support
+
+Bei Problemen:
+1. Überprüfen Sie die GitHub Actions Logs
+2. Schauen Sie in die Google Cloud Console
+3. Überprüfen Sie die Service Logs
+4. Konsultieren Sie die Troubleshooting-Dokumentation

--- a/GITHUB_SECRETS_SETUP.md
+++ b/GITHUB_SECRETS_SETUP.md
@@ -1,0 +1,97 @@
+# GitHub Secrets Setup für Bringee CI/CD
+
+Diese Anleitung zeigt, wie Sie die GitHub Secrets konfigurieren, die für das automatische Deployment in Google Cloud Platform benötigt werden.
+
+## Benötigte Secrets
+
+### 1. GCP_PROJECT_ID
+**Beschreibung:** Die ID Ihres Google Cloud Projekts
+**Wert:** z.B. `bringee-project-123456`
+
+### 2. GCP_SA_KEY
+**Beschreibung:** Der JSON-Schlüssel für den Service Account, der von GitHub Actions verwendet wird
+**Wert:** Der komplette JSON-Inhalt der Service Account Key-Datei
+
+## Schritt-für-Schritt Anleitung
+
+### Schritt 1: Google Cloud Service Account erstellen
+
+1. Gehen Sie zur [Google Cloud Console](https://console.cloud.google.com/)
+2. Wählen Sie Ihr Projekt aus
+3. Gehen Sie zu "IAM & Admin" > "Service Accounts"
+4. Klicken Sie auf "Create Service Account"
+5. Geben Sie einen Namen ein (z.B. `github-actions`)
+6. Klicken Sie auf "Create and Continue"
+7. Fügen Sie die folgenden Rollen hinzu:
+   - Cloud Run Admin
+   - Storage Admin
+   - Artifact Registry Admin
+   - Service Account User
+8. Klicken Sie auf "Done"
+
+### Schritt 2: Service Account Key erstellen
+
+1. Klicken Sie auf den erstellten Service Account
+2. Gehen Sie zum Tab "Keys"
+3. Klicken Sie auf "Add Key" > "Create new key"
+4. Wählen Sie "JSON" aus
+5. Klicken Sie auf "Create"
+6. Die JSON-Datei wird automatisch heruntergeladen
+
+### Schritt 3: GitHub Secrets konfigurieren
+
+1. Gehen Sie zu Ihrem GitHub Repository
+2. Klicken Sie auf "Settings"
+3. Klicken Sie auf "Secrets and variables" > "Actions"
+4. Klicken Sie auf "New repository secret"
+
+#### Secret 1: GCP_PROJECT_ID
+- **Name:** `GCP_PROJECT_ID`
+- **Value:** Ihre GCP Project ID (z.B. `bringee-project-123456`)
+
+#### Secret 2: GCP_SA_KEY
+- **Name:** `GCP_SA_KEY`
+- **Value:** Der komplette Inhalt der heruntergeladenen JSON-Datei
+
+### Schritt 4: Workload Identity Provider konfigurieren (Optional)
+
+Für eine sicherere Authentifizierung können Sie Workload Identity verwenden:
+
+1. Führen Sie das Terraform-Setup aus:
+   ```bash
+   ./setup-gcp-deployment.sh
+   ```
+
+2. Das Skript erstellt automatisch einen Workload Identity Provider
+
+3. Verwenden Sie dann diese Secrets:
+   - `GCP_PROJECT_ID`: Ihre GCP Project ID
+   - `GITHUB_ACTIONS_SA_EMAIL`: Die E-Mail des Service Accounts (wird von Terraform erstellt)
+
+## Verwendung
+
+Nach der Konfiguration der Secrets:
+
+1. Pushen Sie einen Commit zum `main` Branch
+2. Die GitHub Actions werden automatisch ausgelöst
+3. Die Services werden automatisch deployed
+
+## Troubleshooting
+
+### Fehler: "Permission denied"
+- Überprüfen Sie, ob der Service Account die richtigen Rollen hat
+- Stellen Sie sicher, dass die GCP_SA_KEY korrekt kopiert wurde
+
+### Fehler: "Project not found"
+- Überprüfen Sie, ob die GCP_PROJECT_ID korrekt ist
+- Stellen Sie sicher, dass das Projekt existiert und Sie Zugriff haben
+
+### Fehler: "Artifact Registry not found"
+- Das Terraform-Setup muss zuerst ausgeführt werden
+- Führen Sie `./setup-gcp-deployment.sh` aus
+
+## Nützliche Links
+
+- [Google Cloud IAM Documentation](https://cloud.google.com/iam/docs)
+- [GitHub Actions Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+- [Google Cloud Run Documentation](https://cloud.google.com/run/docs)

--- a/deploy-to-gcp.sh
+++ b/deploy-to-gcp.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+
+# Bringee GCP Deployment Script
+# This script deploys the application to Google Cloud Platform
+
+set -e
+
+echo "🚀 Deploying Bringee to Google Cloud Platform"
+echo "=============================================="
+
+# Configuration
+GCP_PROJECT_ID=${GCP_PROJECT_ID:-"bringee-project"}
+GCP_REGION=${GCP_REGION:-"europe-west3"}
+GITHUB_REPO=${GITHUB_REPO:-"your-username/bringee"}
+
+echo "Configuration:"
+echo "  GCP Project ID: $GCP_PROJECT_ID"
+echo "  GCP Region: $GCP_REGION"
+echo "  GitHub Repo: $GITHUB_REPO"
+echo ""
+
+# Check if we're in a GitHub Actions environment
+if [ -n "$GITHUB_ACTIONS" ]; then
+    echo "✅ Running in GitHub Actions environment"
+    echo "The CI/CD pipeline will handle the deployment automatically"
+    echo ""
+    echo "Make sure the following GitHub secrets are configured:"
+    echo "  - GCP_PROJECT_ID: $GCP_PROJECT_ID"
+    echo "  - GCP_SA_KEY: Your Google Cloud Service Account key"
+    echo ""
+    echo "To configure these secrets:"
+    echo "1. Go to your GitHub repository: https://github.com/$GITHUB_REPO"
+    echo "2. Go to Settings > Secrets and variables > Actions"
+    echo "3. Add the secrets listed above"
+    echo ""
+    echo "Then push a commit to the main branch to trigger deployment"
+    exit 0
+fi
+
+# Check if required tools are installed
+check_requirements() {
+    echo "📋 Checking requirements..."
+    
+    if ! command -v gcloud &> /dev/null; then
+        echo "❌ Google Cloud SDK is not installed."
+        echo "Please install it first: https://cloud.google.com/sdk/docs/install"
+        echo ""
+        echo "For Ubuntu/Debian:"
+        echo "  curl https://sdk.cloud.google.com | bash"
+        echo "  exec -l $SHELL"
+        echo "  gcloud init"
+        exit 1
+    fi
+    
+    if ! command -v terraform &> /dev/null; then
+        echo "❌ Terraform is not installed."
+        echo "Please install it first: https://developer.hashicorp.com/terraform/downloads"
+        exit 1
+    fi
+    
+    echo "✅ All requirements met"
+}
+
+# Authenticate with Google Cloud
+authenticate_gcp() {
+    echo "🔐 Authenticating with Google Cloud..."
+    
+    if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q .; then
+        echo "Please authenticate with Google Cloud:"
+        gcloud auth login
+    fi
+    
+    echo "Setting project to $GCP_PROJECT_ID..."
+    gcloud config set project "$GCP_PROJECT_ID"
+    
+    echo "✅ Google Cloud authentication complete"
+}
+
+# Deploy infrastructure with Terraform
+deploy_infrastructure() {
+    echo "🏗️  Deploying infrastructure with Terraform..."
+    
+    cd terraform
+    
+    # Create terraform.tfvars
+    cat > terraform.tfvars << EOF
+gcp_project_id = "$GCP_PROJECT_ID"
+gcp_region     = "$GCP_REGION"
+github_repository = "$GITHUB_REPO"
+EOF
+    
+    # Initialize Terraform
+    terraform init
+    
+    # Plan and apply
+    terraform plan -out=tfplan
+    terraform apply tfplan
+    
+    # Get outputs
+    GITHUB_ACTIONS_SA_EMAIL=$(terraform output -raw github_actions_sa_email 2>/dev/null || echo "")
+    USER_SERVICE_URL=$(terraform output -raw user_service_url 2>/dev/null || echo "")
+    SHIPMENT_SERVICE_URL=$(terraform output -raw shipment_service_url 2>/dev/null || echo "")
+    
+    cd ..
+    
+    echo "✅ Infrastructure deployed"
+}
+
+# Build and deploy services manually
+build_and_deploy_services() {
+    echo "🔨 Building and deploying services..."
+    
+    # Build and deploy user-service
+    echo "Building user-service..."
+    cd backend/services/user-service
+    go build -o server .
+    
+    # Create Docker image
+    docker build -t gcr.io/$GCP_PROJECT_ID/user-service:latest .
+    docker push gcr.io/$GCP_PROJECT_ID/user-service:latest
+    
+    # Deploy to Cloud Run
+    gcloud run deploy user-service \
+        --image gcr.io/$GCP_PROJECT_ID/user-service:latest \
+        --region $GCP_REGION \
+        --platform managed \
+        --allow-unauthenticated \
+        --port 8080 \
+        --memory 512Mi \
+        --cpu 1 \
+        --max-instances 10
+    
+    cd ../../..
+    
+    # Build and deploy shipment-service
+    echo "Building shipment-service..."
+    cd backend/services/shipment-service
+    go build -o server .
+    
+    # Create Docker image
+    docker build -t gcr.io/$GCP_PROJECT_ID/shipment-service:latest .
+    docker push gcr.io/$GCP_PROJECT_ID/shipment-service:latest
+    
+    # Deploy to Cloud Run
+    gcloud run deploy shipment-service \
+        --image gcr.io/$GCP_PROJECT_ID/shipment-service:latest \
+        --region $GCP_REGION \
+        --platform managed \
+        --allow-unauthenticated \
+        --port 8080 \
+        --memory 512Mi \
+        --cpu 1 \
+        --max-instances 10
+    
+    cd ../../..
+    
+    echo "✅ Services deployed"
+}
+
+# Deploy frontend
+deploy_frontend() {
+    echo "🌐 Deploying frontend..."
+    
+    cd frontend/bringee_app
+    
+    # Build Flutter web app
+    flutter build web --release
+    
+    # Deploy to Firebase Hosting (if configured)
+    if [ -f "firebase.json" ]; then
+        firebase deploy --only hosting --project $GCP_PROJECT_ID
+    else
+        echo "Firebase configuration not found. Please configure Firebase Hosting manually."
+    fi
+    
+    cd ../..
+    
+    echo "✅ Frontend deployed"
+}
+
+# Main execution
+main() {
+    check_requirements
+    authenticate_gcp
+    deploy_infrastructure
+    build_and_deploy_services
+    deploy_frontend
+    
+    echo ""
+    echo "🎉 Deployment complete!"
+    echo "====================="
+    echo ""
+    echo "Your services are now deployed:"
+    [ -n "$USER_SERVICE_URL" ] && echo "• User Service: $USER_SERVICE_URL"
+    [ -n "$SHIPMENT_SERVICE_URL" ] && echo "• Shipment Service: $SHIPMENT_SERVICE_URL"
+    echo ""
+    echo "Next steps:"
+    echo "1. Configure GitHub secrets for CI/CD"
+    echo "2. Test the deployed services"
+    echo "3. Set up monitoring and logging"
+}
+
+# Run the script
+main "$@"


### PR DESCRIPTION
Add scripts and documentation to enable Google Cloud Platform deployment.

The user reported that the application was not yet running on GCP. This PR provides the necessary automation script (`deploy-to-gcp.sh`) and detailed instructions (`GITHUB_SECRETS_SETUP.md`, `DEPLOYMENT_CHECKLIST.md`) to facilitate the initial and ongoing deployment of the application's infrastructure, backend, and frontend components to Google Cloud, either manually or via GitHub Actions CI/CD.