### PR TITLE
Lösen den merge konflikt

### DIFF
--- a/frontend/bringee_app/lib/main.dart
+++ b/frontend/bringee_app/lib/main.dart
@@ -27,7 +27,15 @@ class BringeeApp extends ConsumerWidget {
           foregroundColor: Colors.white,
         ),
       ),
-      home: const MainScreen(),
+      home: authState.when(
+        data: (user) => user != null ? const MainScreen() : const AuthScreen(),
+        loading: () => const Scaffold(
+          body: Center(
+            child: CircularProgressIndicator(),
+          ),
+        ),
+        error: (error, stack) => const AuthScreen(),
+      ),
     );
   }
 }
@@ -241,15 +249,6 @@ class _ActionCard extends StatelessWidget {
             ],
           ),
         ),
-      ),
-      home: authState.when(
-        data: (user) => user != null ? const HomeScreen() : const AuthScreen(),
-        loading: () => const Scaffold(
-          body: Center(
-            child: CircularProgressIndicator(),
-          ),
-        ),
-        error: (error, stack) => const AuthScreen(),
       ),
     );
   }


### PR DESCRIPTION
Correct `MaterialApp`'s home property and remove misplaced authentication logic from `_ActionCard` to resolve a merge conflict.

The merge conflict introduced a misplaced `home:` property within the `_ActionCard` widget. This PR moves the authentication state logic to the `MaterialApp`'s `home` property, where it correctly determines the initial screen based on user authentication.